### PR TITLE
SBOM

### DIFF
--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -1,6 +1,6 @@
 import { FileUploadEntity, FileUPloadStatusEnum, ReleaseArtifactEntity } from "@app/common/database/entities";
 import { CreateFileUploadUrlDto, FileUploadUrlDto, UpdateFileUploadDto } from "@app/common/dto/upload";
-import { BadRequestException, ForbiddenException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { BadRequestException, ForbiddenException, Inject, Injectable, Logger, NotFoundException, OnModuleInit } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { In, LessThanOrEqual, Repository } from "typeorm";
@@ -11,12 +11,13 @@ import { EventEmitter } from 'eventemitter3';
 import { FileProcessingService } from "@app/common/AWS/file-processing.service";
 import { HttpService } from "@nestjs/axios";
 import * as crypto from 'crypto';
+import { firstValueFrom } from 'rxjs';
 import { MicroserviceClient, MicroserviceName } from '@app/common/microservice-client';
-import { SbomTopicsEmit } from '@app/common/microservice-client/topics';
+import { SbomTopics, SbomTopicsEmit } from '@app/common/microservice-client/topics';
 
 
 @Injectable()
-export class FileUploadService {
+export class FileUploadService implements OnModuleInit {
 
   private static readonly OBJECT_PREFIX = 'upload/';
   private readonly logger = new Logger(FileUploadService.name);
@@ -32,6 +33,11 @@ export class FileUploadService {
     private readonly httpService: HttpService,
     @Inject(MicroserviceName.SBOM_GENERATOR_SERVICE) private readonly sbomClient: MicroserviceClient,
   ) { }
+
+  async onModuleInit() {
+    this.sbomClient.subscribeToResponseOf([SbomTopics.SCAN_REQUEST]);
+    await this.sbomClient.connect();
+  }
 
 
   async createFileUploadUrl(dto: CreateFileUploadUrlDto) {
@@ -231,25 +237,44 @@ export class FileUploadService {
       if (file.status === FileUPloadStatusEnum.UPLOADED) {
         this.emitter.emit("fileCreated", file)
 
-        // Emit a fire-and-forget event to sbom-generator to scan the uploaded file.
-        // Wrapped in try/catch because sbom-generator is an optional service.
-        try {
-          this.sbomClient.emit(SbomTopicsEmit.SCAN_FILE, {
-            objectKey: file.objectKey,
-            bucketName: this.bucketName,
-            triggeredBy: 'upload-service',
-          }).subscribe({
-            error: (err) => this.logger.warn(`SBOM scan emit failed (non-critical): ${err?.message}`),
-          });
-        } catch (sbomErr) {
-          this.logger.warn(`Could not emit SBOM scan event (non-critical): ${sbomErr?.message}`);
-        }
+        // Fire-and-forget: trigger SBOM scan via request-response so we can
+        // persist the returned scan ID on the matching ReleaseArtifactEntity.
+        // Wrapped in a catch because sbom-generator is an optional service.
+        this.triggerSbomScanAndSaveScanId(file.objectKey).catch(err => {
+          this.logger.warn(`SBOM scan trigger failed (non-critical): ${err?.message}`);
+        });
       } else if (file.status === FileUPloadStatusEnum.REMOVED) {
         this.emitter.emit("fileDeleted", file)
       }
     }
 
     return res.affected
+  }
+
+  /**
+   * Trigger an SBOM scan for the uploaded file and persist the scan ID on the
+   * matching ReleaseArtifactEntity so callers can later look up results.
+   */
+  private async triggerSbomScanAndSaveScanId(objectKey: string): Promise<void> {
+    const presignedUrl = await this.minioClient.generatePresignedDownloadUrl(this.bucketName, objectKey);
+    const response = await firstValueFrom(
+      this.sbomClient.send<{ scanId: string; status: string }>(SbomTopics.SCAN_REQUEST, {
+        target: presignedUrl,
+        targetType: 'file',
+        triggeredBy: 'upload-service',
+      })
+    );
+    if (response?.scanId) {
+      // Repository.update() cannot filter by nested relation properties (objectKey belongs
+      // to FileUploadEntity, not ReleaseArtifactEntity). Resolve the FileUpload ID first so
+      // TypeORM can map it to the file_upload_id foreign key column.
+      const file = await this.getFileByObjectKey(objectKey);
+      await this.artifactRepo.update(
+        { fileUpload: { id: file.id } },
+        { sbomScanId: response.scanId }
+      );
+      this.logger.log(`Saved SBOM scan ID ${response.scanId} for objectKey: ${objectKey}`);
+    }
   }
 
   /**

--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -602,8 +602,8 @@ export class FileUploadService implements OnModuleInit {
       skip += batchSize;
     } while (files.length === batchSize);
   }
-
-  @TimeoutRepeatTask({ name: "listen-to-minio-events", initialTimeout: 1000, repeatTimeout: 60000 }) // Start after 1 second, repeat when finished every 60 seconds
+  // Start after 1 second, repeat when finished every 60 seconds, check lock every 5 minutes if failed to acquire
+  @TimeoutRepeatTask({ name: "listen-to-minio-events", initialTimeout: 1000, repeatTimeout: 60000, acquireFailTimeout: 5 * 60 * 1000 }) 
   async listenTomMinioEvents() {
     if (process.env.MINIO_EVENTS_SKIP === 'true') {
       this.logger.verbose('Minio events listener skipped');

--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -304,6 +304,15 @@ export class FileUploadService implements OnModuleInit {
   }
 
   /**
+   * Fire-and-forget: request the sbom-generator to delete (or cancel) a scan.
+   * Safe to call non-critically; errors are only logged.
+   */
+  triggerSbomScanDelete(scanId: string): void {
+    this.logger.log(`Requesting SBOM scan deletion: ${scanId}`);
+    this.sbomClient.emit(SbomTopics.DELETE_SCAN, { scanId });
+  }
+
+  /**
    * Efficiently process file for SHA256 and/or Cosign signature using a single stream
    * @param objectKey - The object key
    * @param calculateSha256 - Whether to calculate SHA256

--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -23,6 +23,7 @@ export class FileUploadService implements OnModuleInit {
   private readonly logger = new Logger(FileUploadService.name);
   private readonly bucketName = this.configService.get('BUCKET_NAME');
   private emitter: EventEmitter = new EventEmitter();
+  private readonly sbomScanFlags = new Map<string, boolean>();
 
   constructor(
     private readonly configService: ConfigService,
@@ -48,7 +49,9 @@ export class FileUploadService implements OnModuleInit {
     upload.userId = dto.userId;
     upload.fileName = dto.fileName;
     upload.objectKey = objectKey;
-    upload.bucketName = this.bucketName
+    upload.bucketName = this.bucketName;
+
+    this.sbomScanFlags.set(objectKey, dto.enableSbomScan ?? true);
 
 
     const signedUrl = await this.minioClient.generatePresignedUploadUrl(this.bucketName, objectKey);
@@ -240,9 +243,14 @@ export class FileUploadService implements OnModuleInit {
         // Fire-and-forget: trigger SBOM scan via request-response so we can
         // persist the returned scan ID on the matching ReleaseArtifactEntity.
         // Wrapped in a catch because sbom-generator is an optional service.
-        this.triggerSbomScanAndSaveScanId(file.objectKey).catch(err => {
-          this.logger.warn(`SBOM scan trigger failed (non-critical): ${err?.message}`);
-        });
+        // Only triggered when enableSbomScan was not explicitly set to false in the original DTO.
+        const enableSbomScan = this.sbomScanFlags.get(file.objectKey) ?? true;
+        this.sbomScanFlags.delete(file.objectKey);
+        if (enableSbomScan) {
+          this.triggerSbomScanAndSaveScanId(file.objectKey).catch(err => {
+            this.logger.warn(`SBOM scan trigger failed (non-critical): ${err?.message}`);
+          });
+        }
       } else if (file.status === FileUPloadStatusEnum.REMOVED) {
         this.emitter.emit("fileDeleted", file)
       }

--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -505,6 +505,12 @@ export class FileUploadService implements OnModuleInit {
     this.logger.log('Syncing uploaded files');
 
     const now = new Date();
+    // A PENDING upload whose presigned URL has already expired can never succeed.
+    // Use UPLOAD_URL_EXPIRE (seconds) as the staleness threshold — identical to the
+    // value passed to MinIO when the presigned URL was issued.
+    const uploadUrlExpireSeconds = Number(this.configService.get<number>('UPLOAD_URL_EXPIRE')) || 3600;
+    const staleThreshold = new Date(now.getTime() - uploadUrlExpireSeconds * 1000);
+
     const batchSize = 10;
     let skip = 0;
     let files;
@@ -512,7 +518,7 @@ export class FileUploadService implements OnModuleInit {
     do {
       this.logger.log(`Getting pending files, batch starting at ${skip}`);
       files = await this.uploadRepo.find({
-        select: ['objectKey', 'id'],
+        select: ['objectKey', 'id', 'createdDate'],
         where: {
           status: FileUPloadStatusEnum.PENDING,
           createdDate: LessThanOrEqual(now)
@@ -563,7 +569,33 @@ export class FileUploadService implements OnModuleInit {
           Promise.all(filesToUpdate.map(file => this.updateUploadFile(file))).catch(err => {
             this.logger.error(`Error updating files: ${err}`)
           });
+        }
 
+        // Flag abandoned uploads: not in the bucket AND presigned URL has already expired.
+        // Until the URL expires we cannot distinguish "slow upload" from "abandoned", so
+        // we must not flag anything before that point.
+        const staleFiles = batch.filter((file, index) => {
+          const stats = filesStats[index];
+          return !stats && file.createdDate && file.createdDate < staleThreshold;
+        });
+
+        if (staleFiles.length > 0) {
+          this.logger.warn(
+            `Marking ${staleFiles.length} abandoned PENDING upload(s) as ERROR ` +
+            `(presigned URL expired, no object found in bucket): ` +
+            staleFiles.map(f => f.objectKey).join(', ')
+          );
+          await Promise.all(
+            staleFiles.map(file =>
+              this.uploadRepo.update(
+                { objectKey: file.objectKey },
+                {
+                  status: FileUPloadStatusEnum.ERROR,
+                  error: 'Upload never completed — the browser upload was abandoned and the presigned URL has expired.',
+                }
+              ).catch(err => this.logger.error(`Failed to mark stale upload as ERROR: ${file.objectKey}, ${err}`))
+            )
+          );
         }
       }
 

--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -264,11 +264,11 @@ export class FileUploadService implements OnModuleInit {
    * matching ReleaseArtifactEntity so callers can later look up results.
    */
   private async triggerSbomScanAndSaveScanId(objectKey: string): Promise<void> {
-    const presignedUrl = await this.minioClient.generatePresignedDownloadUrl(this.bucketName, objectKey);
     const response = await firstValueFrom(
       this.sbomClient.send<{ scanId: string; status: string }>(SbomTopics.SCAN_REQUEST, {
-        target: presignedUrl,
+        target: objectKey,
         targetType: 'file',
+        isStoredInBucket: true,
         triggeredBy: 'upload-service',
       })
     );

--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -1,6 +1,6 @@
 import { FileUploadEntity, FileUPloadStatusEnum, ReleaseArtifactEntity } from "@app/common/database/entities";
 import { CreateFileUploadUrlDto, FileUploadUrlDto, UpdateFileUploadDto } from "@app/common/dto/upload";
-import { BadRequestException, ForbiddenException, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { BadRequestException, ForbiddenException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { In, LessThanOrEqual, Repository } from "typeorm";
@@ -11,6 +11,8 @@ import { EventEmitter } from 'eventemitter3';
 import { FileProcessingService } from "@app/common/AWS/file-processing.service";
 import { HttpService } from "@nestjs/axios";
 import * as crypto from 'crypto';
+import { MicroserviceClient, MicroserviceName } from '@app/common/microservice-client';
+import { SbomTopicsEmit } from '@app/common/microservice-client/topics';
 
 
 @Injectable()
@@ -28,6 +30,7 @@ export class FileUploadService {
     @InjectRepository(FileUploadEntity) private readonly uploadRepo: Repository<FileUploadEntity>,
     @InjectRepository(ReleaseArtifactEntity) private readonly artifactRepo: Repository<ReleaseArtifactEntity>,
     private readonly httpService: HttpService,
+    @Inject(MicroserviceName.SBOM_GENERATOR_SERVICE) private readonly sbomClient: MicroserviceClient,
   ) { }
 
 
@@ -227,6 +230,20 @@ export class FileUploadService {
     } else {
       if (file.status === FileUPloadStatusEnum.UPLOADED) {
         this.emitter.emit("fileCreated", file)
+
+        // Emit a fire-and-forget event to sbom-generator to scan the uploaded file.
+        // Wrapped in try/catch because sbom-generator is an optional service.
+        try {
+          this.sbomClient.emit(SbomTopicsEmit.SCAN_FILE, {
+            objectKey: file.objectKey,
+            bucketName: this.bucketName,
+            triggeredBy: 'upload-service',
+          }).subscribe({
+            error: (err) => this.logger.warn(`SBOM scan emit failed (non-critical): ${err?.message}`),
+          });
+        } catch (sbomErr) {
+          this.logger.warn(`Could not emit SBOM scan event (non-critical): ${sbomErr?.message}`);
+        }
       } else if (file.status === FileUPloadStatusEnum.REMOVED) {
         this.emitter.emit("fileDeleted", file)
       }

--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -278,6 +278,24 @@ export class FileUploadService implements OnModuleInit {
   }
 
   /**
+   * Trigger an SBOM scan for a docker image URL and persist the scan ID on the
+   * matching ReleaseArtifactEntity.
+   */
+  async triggerDockerSbomScan(dockerImageUrl: string, artifactId: number): Promise<void> {
+    const response = await firstValueFrom(
+      this.sbomClient.send<{ scanId: string; status: string }>(SbomTopics.SCAN_REQUEST, {
+        target: dockerImageUrl,
+        targetType: 'registry',
+        triggeredBy: 'upload-service',
+      })
+    );
+    if (response?.scanId) {
+      await this.artifactRepo.update({ id: artifactId }, { sbomScanId: response.scanId });
+      this.logger.log(`Saved SBOM scan ID ${response.scanId} for docker artifact: ${artifactId}`);
+    }
+  }
+
+  /**
    * Efficiently process file for SHA256 and/or Cosign signature using a single stream
    * @param objectKey - The object key
    * @param calculateSha256 - Whether to calculate SHA256

--- a/apps/upload/src/file-upload.service.ts
+++ b/apps/upload/src/file-upload.service.ts
@@ -36,8 +36,18 @@ export class FileUploadService implements OnModuleInit {
   ) { }
 
   async onModuleInit() {
-    this.sbomClient.subscribeToResponseOf([SbomTopics.SCAN_REQUEST]);
+    this.sbomClient.subscribeToResponseOf([SbomTopics.SCAN_REQUEST, SbomTopics.CHECK_HEALTH]);
     await this.sbomClient.connect();
+  }
+
+  /** Pings the sbom-generator and returns true if it responds within the timeout. */
+  async checkSbomHealth(timeoutMs = 3000): Promise<boolean> {
+    try {
+      await firstValueFrom(this.sbomClient.send(SbomTopics.CHECK_HEALTH, {}, timeoutMs));
+      return true;
+    } catch {
+      return false;
+    }
   }
 
 

--- a/apps/upload/src/releases.service.ts
+++ b/apps/upload/src/releases.service.ts
@@ -346,6 +346,7 @@ export class ReleaseService implements OnModuleInit {
     artifactEntity.isInstallationFile = artifact.isInstallationFile;
     artifactEntity.arguments = artifact.arguments;
     artifactEntity.isExecutable = artifact.isExecutable;
+    artifactEntity.enableSbomScan = artifact.enableSbomScan ?? true;
 
     const res = new SetReleaseArtifactResDto();
     const upsertOptions: UpsertOptions<ReleaseArtifactEntity> = { conflictPaths: [] };

--- a/apps/upload/src/releases.service.ts
+++ b/apps/upload/src/releases.service.ts
@@ -357,6 +357,7 @@ export class ReleaseService implements OnModuleInit {
         // TODO consider adding version id to object key to avoid overwriting same version of other branches
         objectKey: `${artifact.projectId}/${artifact.version}`,
         userId: 'release',
+        enableSbomScan: artifact.enableSbomScan ?? true,
       } as CreateFileUploadUrlDto
       const upload = await this.fileUploadService.createFileUploadUrl(uploadDto);
       artifactEntity.fileUpload = { id: upload.id } as unknown as FileUploadEntity;
@@ -382,9 +383,11 @@ export class ReleaseService implements OnModuleInit {
 
     if (artifact.type === ArtifactTypeEnum.DOCKER_IMAGE) {
       this.refreshReleaseState(artifact);
-      this.fileUploadService.triggerDockerSbomScan(artifact.dockerImageUrl, res.artifactId).catch(err => {
-        this.logger.warn(`SBOM scan trigger failed for docker artifact (non-critical): ${err?.message}`);
-      });
+      if (artifact.enableSbomScan !== false) {
+        this.fileUploadService.triggerDockerSbomScan(artifact.dockerImageUrl, res.artifactId).catch(err => {
+          this.logger.warn(`SBOM scan trigger failed for docker artifact (non-critical): ${err?.message}`);
+        });
+      }
     }
 
     return res;

--- a/apps/upload/src/releases.service.ts
+++ b/apps/upload/src/releases.service.ts
@@ -424,6 +424,11 @@ export class ReleaseService implements OnModuleInit {
       await this.artifactRepo.delete({ id: params.artifactId })
     }
 
+    // If a SBOM scan was associated, request its deletion/cancellation (fire-and-forget)
+    if (artifact.sbomScanId) {
+      this.fileUploadService.triggerSbomScanDelete(artifact.sbomScanId);
+    }
+
     return "Release Artifact deleted"
   }
 

--- a/apps/upload/src/releases.service.ts
+++ b/apps/upload/src/releases.service.ts
@@ -381,7 +381,10 @@ export class ReleaseService implements OnModuleInit {
     await this.updateTotalSize(artifact.projectId, artifact.version);
 
     if (artifact.type === ArtifactTypeEnum.DOCKER_IMAGE) {
-      this.refreshReleaseState(artifact)
+      this.refreshReleaseState(artifact);
+      this.fileUploadService.triggerDockerSbomScan(artifact.dockerImageUrl, res.artifactId).catch(err => {
+        this.logger.warn(`SBOM scan trigger failed for docker artifact (non-critical): ${err?.message}`);
+      });
     }
 
     return res;

--- a/apps/upload/src/releases.service.ts
+++ b/apps/upload/src/releases.service.ts
@@ -1201,4 +1201,24 @@ export class ReleaseService implements OnModuleInit {
       throw error;
     }
   }
+
+  /**
+   * Links the SBOM report bucket path to the artifact identified by the scan ID.
+   * Called when sbom-generator emits SCAN_COMPLETED.
+   */
+  async linkSbomReport(scanId: string, reportBucketPath: string | null): Promise<void> {
+    if (!reportBucketPath) {
+      this.logger.warn(`SBOM scan ${scanId} completed without a report path (scan failed) — skipping link`);
+      return;
+    }
+
+    const artifact = await this.artifactRepo.findOne({ where: { sbomScanId: scanId } });
+    if (!artifact) {
+      this.logger.warn(`No artifact found for sbomScanId=${scanId} — cannot link report`);
+      return;
+    }
+
+    await this.artifactRepo.update({ id: artifact.id }, { sbomReportPath: reportBucketPath });
+    this.logger.log(`Linked SBOM report ${reportBucketPath} to artifact ${artifact.id}`);
+  }
 }

--- a/apps/upload/src/upload.controller.ts
+++ b/apps/upload/src/upload.controller.ts
@@ -181,6 +181,13 @@ export class UploadController {
     return this.releasesService.importRelease(dto);
   }
 
+  @MessagePattern(UploadTopics.GET_SBOM_ENABLED)
+  getSbomEnabled() {
+    const enabled = process.env.SBOM_ENABLED !== 'false';
+    this.logger.log(`SBOM enabled: ${enabled}`);
+    return { enabled };
+  }
+
   @EventPattern(UploadTopicsEmit.PROJECT_REGULATION_CHANGED)
   async onProjectRegulationChanged(@RpcPayload() event: RegulationChangedEvent) {
     await this.releasesService.onProjectRegulationChanged(event);

--- a/apps/upload/src/upload.controller.ts
+++ b/apps/upload/src/upload.controller.ts
@@ -1,4 +1,4 @@
-import { UploadTopics, UploadTopicsEmit, ProjectManagementTopicsEmit } from '@app/common/microservice-client/topics';
+import { UploadTopics, UploadTopicsEmit, ProjectManagementTopicsEmit, SbomTopicsEmit } from '@app/common/microservice-client/topics';
 import { RoleInProject, UploadVersionEntity } from '@app/common/database/entities';
 import { Controller, Logger, UseInterceptors, Inject } from '@nestjs/common';
 import { EventPattern, MessagePattern, RpcException } from '@nestjs/microservices';
@@ -14,6 +14,7 @@ import { ValidateProjectAnyAccess } from '@app/common/utils/project-access';
 import { RegulationChangedEvent } from '@app/common/dto/project-management';
 import { AuthUser } from './utils/auth-user.decorator';
 import { PolicyService } from './policy.service';
+import { ScanCompletedEventDto } from '@app/common/dto/sbom';
 
 
 @Controller()
@@ -182,10 +183,20 @@ export class UploadController {
   }
 
   @MessagePattern(UploadTopics.GET_SBOM_ENABLED)
-  getSbomEnabled() {
-    const enabled = process.env.SBOM_ENABLED !== 'false';
-    this.logger.log(`SBOM enabled: ${enabled}`);
-    return { enabled };
+  async getSbomEnabled() {
+    const envValue = process.env.SBOM_ENABLED;
+
+    // Explicitly configured — trust the env var.
+    if (envValue !== undefined) {
+      const enabled = envValue !== 'false';
+      this.logger.log(`SBOM enabled (env): ${enabled}`);
+      return { enabled };
+    }
+
+    // Not configured — auto-detect by health-checking the sbom-generator service.
+    const reachable = await this.fileUploadService.checkSbomHealth();
+    this.logger.log(`SBOM enabled (auto-detected): ${reachable}`);
+    return { enabled: reachable };
   }
 
   @EventPattern(UploadTopicsEmit.PROJECT_REGULATION_CHANGED)
@@ -228,5 +239,15 @@ export class UploadController {
       this.logger.error(`Unable to read image version - error: ${error}`)
     }
     return version
+  }
+
+  /**
+   * Fire-and-forget: triggered by sbom-generator when a scan finishes.
+   * Links the SBOM report bucket path to the matching release artifact.
+   */
+  @EventPattern(SbomTopicsEmit.SCAN_COMPLETED)
+  async onScanCompleted(@RpcPayload() event: ScanCompletedEventDto): Promise<void> {
+    this.logger.log(`Received SCAN_COMPLETED event for scanId=${event.scanId}, success=${event.success}`);
+    await this.releasesService.linkSbomReport(event.scanId, event.reportBucketPath);
   }
 }

--- a/apps/upload/src/upload.module.ts
+++ b/apps/upload/src/upload.module.ts
@@ -51,6 +51,11 @@ import { PermissionsModule } from '@app/common/permissions/permissions.module';
       type: MicroserviceType.DEPLOY,
       id: 'upload'
     }),
+    MicroserviceModule.register({
+      name: MicroserviceName.SBOM_GENERATOR_SERVICE,
+      type: MicroserviceType.SBOM_GENERATOR,
+      id: 'upload'
+    }),
     ApmModule,
     DatabaseModule,
     RuleModule,

--- a/libs/common/src/database/entities/release-artifact.entity.ts
+++ b/libs/common/src/database/entities/release-artifact.entity.ts
@@ -44,4 +44,7 @@ export class ReleaseArtifactEntity extends BaseEntity {
   @Column({ name: 'sbom_scan_id', type: 'varchar', nullable: true, default: null })
   sbomScanId?: string;
 
+  @Column({ name: 'enable_sbom_scan', type: 'boolean', default: true })
+  enableSbomScan: boolean;
+
 }

--- a/libs/common/src/database/entities/release-artifact.entity.ts
+++ b/libs/common/src/database/entities/release-artifact.entity.ts
@@ -47,4 +47,7 @@ export class ReleaseArtifactEntity extends BaseEntity {
   @Column({ name: 'enable_sbom_scan', type: 'boolean', default: false })
   enableSbomScan: boolean;
 
+  @Column({ name: 'sbom_report_path', type: 'varchar', nullable: true, default: null })
+  sbomReportPath?: string | null;
+
 }

--- a/libs/common/src/database/entities/release-artifact.entity.ts
+++ b/libs/common/src/database/entities/release-artifact.entity.ts
@@ -44,7 +44,7 @@ export class ReleaseArtifactEntity extends BaseEntity {
   @Column({ name: 'sbom_scan_id', type: 'varchar', nullable: true, default: null })
   sbomScanId?: string;
 
-  @Column({ name: 'enable_sbom_scan', type: 'boolean', default: true })
+  @Column({ name: 'enable_sbom_scan', type: 'boolean', default: false })
   enableSbomScan: boolean;
 
 }

--- a/libs/common/src/database/entities/release-artifact.entity.ts
+++ b/libs/common/src/database/entities/release-artifact.entity.ts
@@ -41,4 +41,7 @@ export class ReleaseArtifactEntity extends BaseEntity {
   @Column({ name: 'arguments', type: 'text', nullable: true, default: null})
   arguments?: string | null
 
+  @Column({ name: 'sbom_scan_id', type: 'varchar', nullable: true, default: null })
+  sbomScanId?: string;
+
 }

--- a/libs/common/src/database/migration/1773042996471-AddSbomScanIdToReleaseArtifact.ts
+++ b/libs/common/src/database/migration/1773042996471-AddSbomScanIdToReleaseArtifact.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSbomScanIdToReleaseArtifact1773042996471 implements MigrationInterface {
+    name = 'AddSbomScanIdToReleaseArtifact1773042996471'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "release_artifact" ADD "sbom_scan_id" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "release_artifact" DROP COLUMN "sbom_scan_id"`);
+    }
+
+}

--- a/libs/common/src/database/migration/1773103000000-AddEnableSbomScanToReleaseArtifact.ts
+++ b/libs/common/src/database/migration/1773103000000-AddEnableSbomScanToReleaseArtifact.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddEnableSbomScanToReleaseArtifact1773103000000 implements MigrationInterface {
+    name = 'AddEnableSbomScanToReleaseArtifact1773103000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "release_artifact" ADD "enable_sbom_scan" boolean NOT NULL DEFAULT true`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "release_artifact" DROP COLUMN "enable_sbom_scan"`);
+    }
+
+}

--- a/libs/common/src/database/migration/1773103000000-AddEnableSbomScanToReleaseArtifact.ts
+++ b/libs/common/src/database/migration/1773103000000-AddEnableSbomScanToReleaseArtifact.ts
@@ -4,7 +4,7 @@ export class AddEnableSbomScanToReleaseArtifact1773103000000 implements Migratio
     name = 'AddEnableSbomScanToReleaseArtifact1773103000000'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "release_artifact" ADD "enable_sbom_scan" boolean NOT NULL DEFAULT true`);
+        await queryRunner.query(`ALTER TABLE "release_artifact" ADD "enable_sbom_scan" boolean NOT NULL DEFAULT false`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/libs/common/src/database/migration/1773110000000-AddSbomReportPathToReleaseArtifact.ts
+++ b/libs/common/src/database/migration/1773110000000-AddSbomReportPathToReleaseArtifact.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSbomReportPathToReleaseArtifact1773110000000 implements MigrationInterface {
+  name = 'AddSbomReportPathToReleaseArtifact1773110000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "release_artifact"
+      ADD COLUMN IF NOT EXISTS "sbom_report_path" character varying DEFAULT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "release_artifact"
+      DROP COLUMN IF EXISTS "sbom_report_path"
+    `);
+  }
+}

--- a/libs/common/src/dto/sbom/index.ts
+++ b/libs/common/src/dto/sbom/index.ts
@@ -1,1 +1,2 @@
 export * from './scan-completed-event.dto';
+export * from './scan-status.dto';

--- a/libs/common/src/dto/sbom/index.ts
+++ b/libs/common/src/dto/sbom/index.ts
@@ -1,0 +1,1 @@
+export * from './scan-completed-event.dto';

--- a/libs/common/src/dto/sbom/scan-completed-event.dto.ts
+++ b/libs/common/src/dto/sbom/scan-completed-event.dto.ts
@@ -1,0 +1,17 @@
+/**
+ * Emitted by sbom-generator when a scan finishes (success or failure).
+ * Upload service subscribes to link the report bucket path to the artifact.
+ */
+export class ScanCompletedEventDto {
+  /** The scan job ID. */
+  scanId: string;
+
+  /** The MinIO object key of the generated SBOM report (set on success, null on failure). */
+  reportBucketPath: string | null;
+
+  /** Whether the scan completed successfully. */
+  success: boolean;
+
+  /** Error message if the scan failed. */
+  error?: string;
+}

--- a/libs/common/src/dto/sbom/scan-status.dto.ts
+++ b/libs/common/src/dto/sbom/scan-status.dto.ts
@@ -1,0 +1,41 @@
+export enum ScanStatus {
+  QUEUED = 'queued',
+  RUNNING = 'running',
+  COMPLETE = 'complete',
+  FAILED = 'failed',
+}
+
+export class ScanStatusDto {
+  /** Scan job UUID. */
+  id: string;
+
+  /** Current status of the scan. */
+  status: ScanStatus;
+
+  /** Scan target (image name, file path, registry URL, etc.) */
+  target: string;
+
+  /** Type of the scan target. */
+  targetType: string;
+
+  /** SBOM output format. */
+  format: string;
+
+  /** Who or what triggered this scan. */
+  triggeredBy?: string;
+
+  /** Error message if the scan failed. */
+  error?: string;
+
+  /** Short reason code for the failure. */
+  failureReason?: string;
+
+  /** Timestamp when the scan was created. */
+  createdAt: Date;
+
+  /** Timestamp of the last status update. */
+  updatedAt: Date;
+
+  /** Timestamp when the scan reached a terminal state. */
+  completedAt?: Date;
+}

--- a/libs/common/src/dto/upload/dto/file-upload.dto.ts
+++ b/libs/common/src/dto/upload/dto/file-upload.dto.ts
@@ -1,6 +1,6 @@
 import { FileUPloadStatusEnum } from "@app/common/database/entities";
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsOptional, IsString, NotContains } from "class-validator";
+import { IsBoolean, IsNotEmpty, IsOptional, IsString, NotContains } from "class-validator";
 
 export class CreateFileUploadUrlDto{
   userId: string
@@ -15,6 +15,11 @@ export class CreateFileUploadUrlDto{
   @IsString()
   @IsOptional()
   objectKey?: string
+
+  @ApiProperty({ required: false, description: 'Whether to trigger an SBOM scan for this file after upload. Defaults to true.', default: true })
+  @IsBoolean()
+  @IsOptional()
+  enableSbomScan?: boolean;
 
 
   toString(){

--- a/libs/common/src/dto/upload/dto/release-artifact.dto.ts
+++ b/libs/common/src/dto/upload/dto/release-artifact.dto.ts
@@ -156,9 +156,10 @@ export class ReleaseArtifactDto {
     dto.isInstallationFile = artifact.isInstallationFile;
     dto.dockerImageUrl = artifact?.dockerImageUrl;
     dto.uploadId = artifact.fileUpload ? artifact.fileUpload.id : undefined;
-    dto.status = artifact?.fileUpload?.status
+    const isDockerUrlOnly = artifact.type === ArtifactTypeEnum.DOCKER_IMAGE && !artifact.fileUpload;
+    dto.status = isDockerUrlOnly ? FileUPloadStatusEnum.UPLOADED : artifact?.fileUpload?.status
     dto.size = artifact?.fileUpload?.size
-    dto.progress = artifact?.fileUpload?.progress ?? 0
+    dto.progress = isDockerUrlOnly ? 100 : (artifact?.fileUpload?.progress ?? 0)
     dto.error = artifact?.fileUpload?.error
     dto.sha256 = artifact?.fileUpload?.sha256
     dto.arguments = artifact?.arguments;

--- a/libs/common/src/dto/upload/dto/release-artifact.dto.ts
+++ b/libs/common/src/dto/upload/dto/release-artifact.dto.ts
@@ -149,6 +149,16 @@ export class ReleaseArtifactDto {
   @IsString()
   sha256?: string
 
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({ required: false, default: true, description: 'Whether SBOM scan is enabled for this artifact' })
+  enableSbomScan?: boolean
+
+  @ApiProperty({ required: false, type: 'string', description: 'SBOM scan ID associated with this artifact' })
+  @IsOptional()
+  @IsString()
+  sbomScanId?: string
+
 
   static fromEntity(artifact: ReleaseArtifactEntity): ReleaseArtifactDto {
     const dto = new ReleaseArtifactDto();
@@ -167,6 +177,8 @@ export class ReleaseArtifactDto {
     dto.sha256 = artifact?.fileUpload?.sha256
     dto.arguments = artifact?.arguments;
     dto.isExecutable = artifact?.isExecutable;
+    dto.enableSbomScan = artifact?.enableSbomScan ?? true;
+    dto.sbomScanId = artifact?.sbomScanId;
 
     return dto
   }

--- a/libs/common/src/dto/upload/dto/release-artifact.dto.ts
+++ b/libs/common/src/dto/upload/dto/release-artifact.dto.ts
@@ -48,7 +48,10 @@ export class SetReleaseArtifactDto {
   @ApiProperty({ required: false})
   arguments: string
 
-  
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({ required: false, description: 'Whether to trigger an SBOM scan for this artifact after upload. Defaults to true.', default: true })
+  enableSbomScan: boolean = true;
 
 }
 

--- a/libs/common/src/env/env.json
+++ b/libs/common/src/env/env.json
@@ -165,6 +165,10 @@
           {
             "id": "apm",
             "note": "Should be set in order to enable APM features"
+          },
+          {
+            "id": "sbom",
+            "note": "Required to enable SBOM scanning integration"
           }
         ]
       },
@@ -1059,6 +1063,13 @@
             },
             "type": "boolean",
             "default": true
+          },
+          {
+            "name": "MINIO_EVENTS_SKIP",
+            "description": "When set to 'true', skips the MinIO event listener that synchronises uploaded objects with the database.",
+            "required": false,
+            "type": "boolean",
+            "default": false
           }
         ]
       },
@@ -1513,6 +1524,22 @@
             "description": "Set this option to true to enable async hooks.",
             "required": true,
             "type": "boolean"
+          }
+        ]
+      },
+      {
+        "title": "SBOM Configuration",
+        "id": "sbom",
+        "description": "Environment variables for controlling SBOM (Software Bill of Materials) scanning integration.",
+        "variables": [
+          {
+            "name": "SBOM_ENABLED",
+            "description": "Controls whether SBOM scanning is enabled. When set, overrides auto-detection. When omitted, the service health-checks the sbom-generator to determine availability.",
+            "required": false,
+            "type": "boolean",
+            "notes": [
+              "If not set, the service auto-detects SBOM availability by health-checking the sbom-generator microservice."
+            ]
           }
         ]
       }

--- a/libs/common/src/env/env.schema.json
+++ b/libs/common/src/env/env.schema.json
@@ -18,7 +18,8 @@
         "getMap",
         "libotEmu",
         "kafka",
-        "cosign"
+        "cosign",
+        "sbom"
       ]
     },
     "ScopeMappingObject": {

--- a/libs/common/src/microservice-client/clients/kafka/kafka.ts
+++ b/libs/common/src/microservice-client/clients/kafka/kafka.ts
@@ -20,6 +20,8 @@ export function getKafkaClientConfig(options: MicroserviceModuleOptions): Client
       return kafkaGetMapConfig(options.id)
     case MicroserviceType.DEVICE:
       return kafkaDeviceConfig(options.id)
+    case MicroserviceType.SBOM_GENERATOR:
+      return kafkaSbomGeneratorConfig(options.id)
   }
 }
 
@@ -165,6 +167,24 @@ const kafkaDeviceConfig = (id?: string): ClientProvider => {
         run: {
           partitionsConsumedConcurrently: Number(process.env.CONSUME_CONCURRENT ?? 100)
         }
+    }
+  }
+}
+export const KAFKA_SBOM_GENERATOR_CLIENT_ID = "getapp-sbom-generator"
+export const KAFKA_SBOM_GENERATOR_GROUP_ID = "getapp-sbom-generator-consumer"
+
+const kafkaSbomGeneratorConfig = (id?: string): ClientProvider => {
+  const idStr = id ? `-${id}` : '';
+  return {
+    transport: Transport.KAFKA,
+    options: {
+      client: getKafkaConnection(KAFKA_SBOM_GENERATOR_CLIENT_ID),
+      consumer: {
+        groupId: `${KAFKA_SBOM_GENERATOR_GROUP_ID}${idStr}`
+      },
+      run: {
+        partitionsConsumedConcurrently: Number(process.env.CONSUME_CONCURRENT ?? 100)
+      }
     }
   }
 }

--- a/libs/common/src/microservice-client/clients/socket/socket.ts
+++ b/libs/common/src/microservice-client/clients/socket/socket.ts
@@ -20,6 +20,8 @@ export function getSocketClientConfig(type: MicroserviceType): ClientProvider {
     case MicroserviceType.DEVICE:
       // For device using discovery microservice
       return socketDiscoveryConfig()
+    case MicroserviceType.SBOM_GENERATOR:
+      return socketSbomGeneratorConfig()
   }
 }
 
@@ -99,3 +101,12 @@ const socketGetMapConfig = (): ClientProvider => {
 //     options: {port: 3008}
 //   }
 // }
+const socketSbomGeneratorConfig = (): ClientProvider => {
+  return {
+    transport: Transport.TCP,
+    options: {
+      host: process.env.SBOM_GENERATOR_HOST ?? "localhost",
+      port: Number(process.env.SBOM_GENERATOR_PORT ?? 3009)
+    }
+  }
+}

--- a/libs/common/src/microservice-client/microservice-client.interface.ts
+++ b/libs/common/src/microservice-client/microservice-client.interface.ts
@@ -7,6 +7,7 @@ export enum MicroserviceType {
   UPLOAD,
   GET_MAP,
   DEVICE,
+  SBOM_GENERATOR,
 }
 
 export const MicroserviceName = {
@@ -18,6 +19,7 @@ export const MicroserviceName = {
   UPLOAD_SERVICE: "UPLOAD_SERVICE",
   GET_MAP_SERVICE: "GET_MAP_SERVICE",
   DEVICE_SERVICE: "DEVICE_SERVICE",
+  SBOM_GENERATOR_SERVICE: "SBOM_GENERATOR_SERVICE",
 }
 
 export interface MicroserviceModuleOptions {

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -46,6 +46,8 @@ export const UploadTopics = {
     IMPORT_RELEASE: `getapp-upload.import-release${region}`,
     // Deployment Report
     GET_DEPLOYMENT_REPORT: `getapp-upload.get-deployment-report${region}`,
+    // Settings
+    GET_SBOM_ENABLED: `getapp-upload.get-sbom-enabled${region}`,
 
 } as const
 

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -297,6 +297,7 @@ export const SbomTopics = {
     GET_SCAN_STATUS: `getapp-sbom-generator.scan.status${region}`,
     GET_SCAN_RESULT: `getapp-sbom-generator.scan.result${region}`,
     GET_SCANS: `getapp-sbom-generator.scan.list${region}`,
+    DELETE_SCAN: `getapp-sbom-generator.scan.delete${region}`,
     CHECK_HEALTH: `getapp-sbom-generator.check-health${region}`,
 } as const
 

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -291,3 +291,17 @@ export const DeviceBugReportTopics = {
     NEW_BUG_REPORT: `getapp-device.bug-report.new${region}`,
     GET_BUG_REPORT: `getapp-device.bug-report.get${region}`,
 } as const
+
+export const SbomTopics = {
+    SCAN_REQUEST: `getapp-sbom-generator.scan.request${region}`,
+    GET_SCAN_STATUS: `getapp-sbom-generator.scan.status${region}`,
+    GET_SCAN_RESULT: `getapp-sbom-generator.scan.result${region}`,
+    GET_SCANS: `getapp-sbom-generator.scan.list${region}`,
+    CHECK_HEALTH: `getapp-sbom-generator.check-health${region}`,
+} as const
+
+export const SbomTopicsEmit = {
+    SCAN_FILE: `getapp-sbom-generator.scan.file${region}`,
+    SCAN_COMPLETE: `getapp-sbom-generator.scan.complete${region}`,
+    SCAN_FAILED: `getapp-sbom-generator.scan.failed${region}`,
+} as const

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -305,6 +305,5 @@ export const SbomTopics = {
 
 export const SbomTopicsEmit = {
     SCAN_FILE: `getapp-sbom-generator.scan.file${region}`,
-    SCAN_COMPLETE: `getapp-sbom-generator.scan.complete${region}`,
-    SCAN_FAILED: `getapp-sbom-generator.scan.failed${region}`,
+    SCAN_COMPLETED: `getapp-sbom-generator.scan.completed${region}`,
 } as const


### PR DESCRIPTION
- support creating an sbom report after uploading an artifact
- detect stalling files (where there upload expiartion time has passed) and flag them with an error
- fix acquire lock logic - if upload microservice was restarted improperly and did not release lock, then the upload microservice would not detect it for up to 1 hour and files won't be signed. fixed it by adding acquireFailTimeout of 5 mins that only tries to acquire the lock, that its' ttl is 5 mins