### PR TITLE
fixed a bug where project delete would not work

### DIFF
--- a/apps/upload/src/releases.service.ts
+++ b/apps/upload/src/releases.service.ts
@@ -207,12 +207,14 @@ export class ReleaseService implements OnModuleInit {
 
   async getRelease(params: ReleaseParams): Promise<DetailedReleaseDto> {
     this.logger.log(`Getting release for project: ${params.projectIdentifier}, version: ${params.version}`);
-    if (typeof params.projectIdentifier !== 'number') {
+    if (typeof params.projectIdentifier === 'string') {
       const project = await this.releaseRepo.manager.getRepository(ProjectEntity).findOneBy({ name: params.projectIdentifier });
       if (!project) {
         throw new NotFoundException(`Project not found: ${params.projectIdentifier}`);
       }
       params.projectId = project.id;
+    } else if (typeof params.projectIdentifier === 'number') {
+      params.projectId = params.projectIdentifier;
     }
     return this.getReleaseEntity(params).then((release) => {
       if (!release) {


### PR DESCRIPTION
The root cause is a mismatched assumption between the caller and the callee about which field carries the project identity.

The call chain:

project-management service builds new ReleaseParams(projectId, version) — this sets projectId = 89 but leaves projectIdentifier = undefined
It sends this over RPC to the upload service's deleteRelease
deleteRelease calls getRelease(params) where params.projectId = 89, params.projectIdentifier = undefined
The faulty guard in getRelease:


if (typeof params.projectIdentifier !== 'number') {
typeof undefined !== 'number' is true, so it entered the branch and ran:


const project = await this.releaseRepo.manager.getRepository(ProjectEntity)  .findOneBy({ name: undefined });
TypeORM silently ignores undefined in a WHERE clause, so this becomes SELECT * FROM project LIMIT 1 — returning the first row in the table (id=1, not 89).

It then overwrote the already-correct params.projectId = 89 with 1:


params.projectId = project.id; // 1 💥
Everything downstream then used projectId = 1, causing the "Release not found for project: 1" error.

In short: the original intent of the !== 'number' check was "resolve by name if given a string", but undefined also passed that check, triggering a broken DB lookup that silently clobbered the valid projectId.
