### PR TITLE
feat: add bulk policy retrieval for multiple releases and optimize database queries

### DIFF
--- a/apps/upload/src/policy.controller.ts
+++ b/apps/upload/src/policy.controller.ts
@@ -85,6 +85,17 @@ export class PolicyController {
   }
 
   /**
+   * Bulk: get policies for multiple releases in a single query.
+   * Returns a Record<catalogId, policy[]> map.
+   */
+  @MessagePattern(UploadTopics.GET_POLICIES_FOR_RELEASES)
+  async getPoliciesForReleases(@Payload() payload: any) {
+    const catalogIds: string[] = payload.value ?? payload;
+    this.logger.log(`Getting policies for ${catalogIds?.length ?? 0} releases (bulk)`);
+    return this.policyService.getPoliciesForReleases(catalogIds);
+  }
+
+  /**
    * Create a new policy
    */
   @ValidateProjectListAccess('association.releases')

--- a/apps/upload/src/policy.service.ts
+++ b/apps/upload/src/policy.service.ts
@@ -4,6 +4,7 @@ import { RuleType } from '@app/common/rules/enums/rule.enums';
 import { PROJECT_ACCESS_SERVICE, ProjectAccessService } from '@app/common/utils/project-access';
 import { RuleValidationService } from '@app/common/rules/services/rule-validation.service';
 import { RuleService } from '@app/common/rules/services';
+import { RuleDefinition } from '@app/common/rules';
 
 @Injectable()
 export class PolicyService {
@@ -116,6 +117,39 @@ export class PolicyService {
         }
         return definition;
       });
+  }
+
+  /**
+   * Bulk version of getPoliciesForRelease.
+   * Returns a map of catalogId → policies[] so the caller makes ONE DB query
+   * instead of N, avoiding Kafka consumer saturation.
+   */
+  async getPoliciesForReleases(catalogIds: string[]): Promise<Record<string, RuleDefinition[]>> {
+    if (!catalogIds || catalogIds.length === 0) return {};
+
+    const rules = await this.ruleService.findAllForReleases(catalogIds);
+
+    // Group rules by the catalogIds they are associated with
+    const result: Record<string, RuleDefinition[]> = {};
+    for (const id of catalogIds) {
+      result[id] = [];
+    }
+
+    for (const rule of rules) {
+      if (rule.isPush && !rule.isActive) continue;
+      const definition = this.ruleService.ruleEntityToDefinition(rule);
+      if (rule.isPush && rule.isActive) {
+        definition.isActive = false;
+      }
+      for (const ra of rule.releaseAssociations ?? []) {
+        const catalogId = ra.release?.catalogId;
+        if (catalogId && result[catalogId] !== undefined) {
+          result[catalogId].push(definition);
+        }
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -34,6 +34,7 @@ export const UploadTopics = {
     // Rules - Policies
     GET_POLICIES: `getapp-upload.get-policies${region}`,
     GET_POLICIES_FOR_RELEASE: `getapp-upload.get-policies-for-release${region}`,
+    GET_POLICIES_FOR_RELEASES: `getapp-upload.get-policies-for-releases${region}`,
     CREATE_POLICY: `getapp-upload.create-policy${region}`,
     GET_POLICY: `getapp-upload.get-policy${region}`,
     GET_POLICY_INTERNAL: `getapp-upload.get-policy-internal${region}`,

--- a/libs/common/src/rules/services/rule.service.ts
+++ b/libs/common/src/rules/services/rule.service.ts
@@ -248,6 +248,28 @@ export class RuleService implements OnModuleInit {
   }
 
   /**
+   * Fetches all POLICY rules associated with ANY of the given catalogIds in a single query.
+   * More efficient than calling findAll() N times when you need policies for many releases.
+   */
+  async findAllForReleases(catalogIds: string[]): Promise<RuleEntity[]> {
+    if (!catalogIds || catalogIds.length === 0) return [];
+    return this.ruleRepository
+      .createQueryBuilder('rule')
+      .leftJoinAndSelect('rule.releaseAssociations', 'releaseAssoc')
+      .leftJoinAndSelect('releaseAssoc.release', 'release')
+      .leftJoinAndSelect('release.project', 'project')
+      .leftJoinAndSelect('rule.deviceTypeAssociations', 'deviceTypeAssoc')
+      .leftJoinAndSelect('deviceTypeAssoc.deviceType', 'deviceType')
+      .leftJoinAndSelect('rule.deviceAssociations', 'deviceAssoc')
+      .leftJoinAndSelect('deviceAssoc.device', 'device')
+      .leftJoinAndSelect('rule.osAssociations', 'osAssoc')
+      .where('rule.type = :type', { type: RuleType.POLICY })
+      .andWhere('release.catalogId IN (:...catalogIds)', { catalogIds })
+      .orderBy('rule.createdAt', 'DESC')
+      .getMany();
+  }
+
+  /**
    * Converts a RuleEntity to RuleDefinition format
    */
   ruleEntityToDefinition(rule: RuleEntity): RuleDefinition {


### PR DESCRIPTION
This pull request adds efficient bulk retrieval of policy rules for multiple releases, reducing the number of database queries and improving performance for consumers that need policies for many releases at once. The main changes include introducing new bulk endpoints and service methods, as well as updating the topics enum for microservice communication.

**Bulk policy retrieval support:**

* Added a new `getPoliciesForReleases` endpoint to the `PolicyController` to handle requests for policies for multiple releases in a single call.
* Implemented a `getPoliciesForReleases` method in `PolicyService` that returns a map of `catalogId` to policy definitions, grouping results efficiently and avoiding multiple database queries.
* Added a `findAllForReleases` method in `RuleService` to fetch all policy rules associated with any of the given `catalogIds` in a single database query.

**Microservice communication:**

* Introduced a new topic `GET_POLICIES_FOR_RELEASES` in `UploadTopics` to support bulk policy retrieval over the message bus.

**Codebase cleanup:**

* Imported `RuleDefinition` in `policy.service.ts` to support the new return type for bulk retrieval.